### PR TITLE
Remove feedback link

### DIFF
--- a/public_html/index.html
+++ b/public_html/index.html
@@ -137,7 +137,7 @@
         
 
 <div class="phase-banner">
-  <p><a href="https://www.gov.uk/service-manual/phases/alpha.html" class="phase-tag">alpha</a> This is a new service - <a href="/feedback/?next=terms">your feedback</a> will help us to improve it</p>
+  <p><a href="https://www.gov.uk/service-manual/phases/alpha.html" class="phase-tag">alpha</a> This is a new service</p>
 </div>
 <!--end phase-banner-->
 

--- a/templates/pages/index.hbs
+++ b/templates/pages/index.hbs
@@ -3,7 +3,7 @@ pageTitle: Service unavailable
 ---
 
 <div class="phase-banner">
-  <p><a href="https://www.gov.uk/service-manual/phases/alpha.html" class="phase-tag">alpha</a> This is a new service - <a href="/feedback/?next=terms">your feedback</a> will help us to improve it</p>
+  <p><a href="https://www.gov.uk/service-manual/phases/alpha.html" class="phase-tag">alpha</a> This is a new service</p>
 </div>
 <!--end phase-banner-->
 


### PR DESCRIPTION
If service is unavailable, feedback screen would be too, so removing
link to it.
